### PR TITLE
Update README with reference to 'staticbuilder' in INSTALLED_APPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,15 @@ collects your static files into a build directory and, second, it runs some
 shell commands. (Seriously, look at `the source`__. It delegates most of its
 work to Django's ``collectstatic``. And that's A Good Thing.)
 
+To get started, add ``staticbuilder`` to your ``INSTALLED_APPS``:
+
+.. code-block:: python
+
+    INSTALLED_APPS = (
+        ...
+        'staticbuilder',
+    )
+
 To specify the build directory, use the ``STATICBUILDER_BUILD_ROOT`` setting:
 
 .. code-block:: python


### PR DESCRIPTION
I dunno if this falls under the 'too obvious to be worth mentioning' category, but it took me a bit to realize I needed to do this when setting up staticbuilder for the first time.
