### PR TITLE
Add basic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /dist
 /docs/build
+*.pyc
+__pycache__
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+    - "2.7"
+    - "3.5"
+install: pip install tox-travis
+script: tox

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,35 @@
+from __future__ import unicode_literals, print_function, division, absolute_import
+import django
+import os
+import sys
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_files_import():
+    count_files = 0
+    for root, dirs, files in os.walk(os.path.join(BASE_DIR, "staticbuilder")):
+        for filename in files:
+            if filename.endswith(".py"):
+                import_filename(os.path.join(root, filename))
+                count_files += 1
+    if not count_files:
+        raise Exception("No .py files found")
+
+
+def import_filename(filename):
+    module = ".".join(filter(None, filename.replace(BASE_DIR, "", 1).split(os.sep)))[:-3]
+    if module.endswith(".__init__"):
+        module = module[:-9]
+    try:
+        __import__(module)
+    except:
+        print("Cannot import module %s" % module, file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"
+    django.setup()
+    test_files_import()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,14 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SECRET_KEY = 'zomk1gko4kyiy(v^el6)id#h-#8rocoyvpnt$c6f#=-$c=qdx!'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'testdb'
     }
 }
+
+STATICBUILDER_BUILD_ROOT = os.path.join(BASE_DIR, 'build_root')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist =
+    {py27}-django-{18,19,110}
+    {py35}-django-{18,19,110}
+
+[testenv]
+commands = python runtests.py


### PR DESCRIPTION
This adds a file `runtests.py` which can be used to run the tests. Right now, it simply imports all the files to check for basic errors, but it could be expanded in future.

`tox.ini` was added so that you can run `tox` to run the tests against different Python and Django versions automatically.

`.travis.yml` was added so that travis-ci.org would run the tests automatically. You can do cool things like add a badge the README too. It's very easy to set up travis-ci.org to do this, I've done it for my fork, and it could be done very easily for hzdg.

Currently the tests fail because of a couple of bugs in the code.